### PR TITLE
Replace CRA ESLint config with AirBnB and fix code style

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+build/*
+scripts/*
+config/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,43 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "sourceType": "module"
+    },
+    "settings": {
+        "import/resolver": { "webpack": {
+            "config": "config/webpack.config.dev.js"
+            }
+        }
+    },
+    "extends": "airbnb",
+    "rules": {
+        "no-const-assign": "warn",
+        "no-this-before-super": "warn",
+        "no-undef": "warn",
+        "no-unreachable": "warn",
+        "no-unused-vars": "warn",
+        "constructor-super": "warn",
+        "valid-typeof": "warn",
+        "comma-dangle": ["error", {
+            "arrays": "always-multiline",
+            "objects": "always-multiline",
+            "imports": "always-multiline",
+            "exports": "always-multiline",
+            "functions": "ignore"
+        }],
+        "semi": ["error", "never"],
+        "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
+        "no-param-reassign": ["error", { "props": false }]
+    },
+    "plugins": [
+        "babel"
+    ]
+}

--- a/config/jest/CSSStub.js
+++ b/config/jest/CSSStub.js
@@ -1,1 +1,1 @@
-module.exports = {};
+module.exports = {}

--- a/config/jest/FileStub.js
+++ b/config/jest/FileStub.js
@@ -1,1 +1,1 @@
-module.exports = "test-file-stub";
+module.exports = 'test-file-stub'

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -69,6 +69,7 @@ module.exports = {
     publicPath: publicPath
   },
   resolve: {
+    root: paths.appSrc,
     // This allows you to set a fallback for where Webpack should look for modules.
     // We read `NODE_PATH` environment variable in `paths.js` and pass paths here.
     // We use `fallback` instead of `root` because we want `node_modules` to "win"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "autoprefixer": "6.5.1",
     "babel-core": "6.17.0",
-    "babel-eslint": "7.0.0",
+    "babel-eslint": "^7.0.0",
     "babel-jest": "16.0.0",
     "babel-loader": "6.2.5",
     "babel-preset-react-app": "^1.0.0",
@@ -16,13 +16,16 @@
     "css-loader": "0.25.0",
     "detect-port": "1.0.1",
     "dotenv": "^2.0.0",
-    "eslint": "3.8.1",
-    "eslint-config-react-app": "^0.3.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-nodejs": "^1.1.0",
+    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-loader": "1.6.0",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "2.21.0",
-    "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "6.4.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "0.9.0",
     "filesize": "^3.3.0",
@@ -35,13 +38,12 @@
     "jest": "16.0.2",
     "json-loader": "0.5.4",
     "node-sass": "^3.13.0",
-    "object-assign": "4.1.0",
     "path-exists": "2.1.0",
     "postcss-loader": "1.0.0",
-    "promise": "7.1.1",
     "react-addons-css-transition-group": "^15.4.1",
     "react-dev-utils": "^0.4.2",
     "recursive-readdir": "2.1.0",
+    "redux-cli": "^1.9.0",
     "redux-devtools": "^3.3.2",
     "resolve-url-loader": "^1.6.1",
     "rimraf": "^2.5.4",
@@ -52,18 +54,20 @@
     "webpack": "^1.14.0",
     "webpack-dev-server": "1.16.2",
     "webpack-manifest-plugin": "1.1.0",
-    "webpack-strip-block": "^0.1.0",
-    "whatwg-fetch": "1.0.0"
+    "webpack-strip-block": "^0.1.0"
   },
   "dependencies": {
     "express": "^4.15.2",
     "material-design-icons": "^3.0.1",
+    "object-assign": "4.1.0",
+    "promise": "7.1.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^5.0.2",
     "react-toolbox": "^1.3.1",
     "redux": "^3.6.0",
-    "roboto-fontface": "^0.6.0"
+    "roboto-fontface": "^0.6.0",
+    "whatwg-fetch": "1.0.0"
   },
   "scripts": {
     "start": "node scripts/start.js",
@@ -93,9 +97,6 @@
     "presets": [
       "react-app"
     ]
-  },
-  "eslintConfig": {
-    "extends": "react-app"
   },
   "peerDependencies": {
     "immutability-helper": "^2.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,17 +1,17 @@
-const express = require('express');
-const path = require('path');
+const express = require('express')
+const path = require('path')
 
-const app = express();
-const PORT = process.env.PORT || 5000;
+const app = express()
+const PORT = process.env.PORT || 5000
 
 // priority serve any static files
-app.use(express.static(path.resolve(__dirname, '../build')));
+app.use(express.static(path.resolve(__dirname, '../build')))
 
 // all remaining requests return the React app, so it can handle routing
-app.get('*', function(request, response) {
-  response.sendFile(path.resolve(__dirname, '../build', 'index.html'));
-});
+app.get('*', (request, response) => {
+  response.sendFile(path.resolve(__dirname, '../build', 'index.html'))
+})
 
-app.listen(PORT, function () {
-  console.log(`Listening on port ${PORT}`);
-});
+app.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`)
+})

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -1,17 +1,13 @@
-import React, { Component } from 'react'
+import React from 'react'
 
 import TopBar from 'containers/top_bar/TopBar'
 import MainArea from 'containers/main_area/MainArea'
 
-class App extends Component {
-  render() {
-    return (
-      <div>
-        <TopBar />
-        <MainArea />
-      </div>
-    )
-  }
+export default function App() {
+  return (
+    <div>
+      <TopBar />
+      <MainArea />
+    </div>
+  )
 }
-
-export default App

--- a/src/containers/top_bar/TopBar.js
+++ b/src/containers/top_bar/TopBar.js
@@ -1,24 +1,20 @@
-import React, { Component } from 'react'
-
-import styles from './TopBar.scss'
+import React from 'react'
 
 import AppBar from 'react-toolbox/lib/app_bar'
 import Navigation from 'react-toolbox/lib/navigation'
 import Link from 'react-toolbox/lib/link'
+
+import styles from './TopBar.scss'
 import logoImg from './sloboda-logo.png'
 
-class TopBar extends Component {
-  render() {
-    const SlobodaLogo = () => <img src={logoImg} className={styles.slobodaLogo} alt='logo' />
-    return (
-      <AppBar title='Tutorium' leftIcon={<SlobodaLogo />}>
-        <Navigation type='horizontal'>
-        <Link href='#' label='Login' icon='exit_to_app' className={styles.menuLink} />
-        <Link href='#' label='Register' icon='account_circle' className={styles.menuLink} />
+export default function TopBar() {
+  const SlobodaLogo = () => <img src={logoImg} className={styles.slobodaLogo} alt="logo" />
+  return (
+    <AppBar title="Tutorium" leftIcon={<SlobodaLogo />}>
+      <Navigation type="horizontal">
+        <Link href="#" label="Login" icon="exit_to_app" className={styles.menuLink} />
+        <Link href="#" label="Register" icon="account_circle" className={styles.menuLink} />
       </Navigation>
-      </AppBar>
-    )
-  }
+    </AppBar>
+  )
 }
-
-export default TopBar

--- a/src/index.js
+++ b/src/index.js
@@ -1,33 +1,35 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './containers/app/App';
+import 'material-design-icons/iconfont/material-icons.css'
+import 'roboto-fontface/css/roboto/roboto-fontface.css'
+import 'react-toolbox/lib/commons.scss'
+
+import React from 'react'
+import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
-import reducer from 'redux/modules/root_reducer'
 
-import 'material-design-icons/iconfont/material-icons.css';
-import 'roboto-fontface/css/roboto/roboto-fontface.css';
-import 'react-toolbox/lib/commons.scss';
-import './index.scss';
+import reducer from './redux/modules'
+import App from './containers/app/App'
+
+import './index.scss'
 
 const store = createStore(reducer)
-const rootEl = document.getElementById('root');
+const rootEl = document.getElementById('root')
 
 ReactDOM.render(
-   <Provider store={store}>
-      <App />
-   </Provider>,
+  <Provider store={store}>
+    <App />
+  </Provider>,
   rootEl
-);
+)
 
 /* develblock:start */
 if (module.hot) {
   module.hot.accept('./containers/app/App', () => {
-    const NextApp = require('./containers/app/App').default;
+    const NextApp = require('./containers/app/App').default // eslint-disable-line global-require
     ReactDOM.render(
       <NextApp />,
       rootEl
-    );
-  });
+    )
+  })
 }
 /* develblock:end */

--- a/src/redux/modules/auth.js
+++ b/src/redux/modules/auth.js
@@ -1,9 +1,9 @@
 const initialState = {
-  signedIn: false
+  signedIn: false,
 }
 
 export default function reducer(state = initialState, action = {}) {
   return {
-    ...state
+    ...state,
   }
 }

--- a/src/redux/modules/index.js
+++ b/src/redux/modules/index.js
@@ -1,7 +1,7 @@
-import { combineReducers } from 'redux';
+import { combineReducers } from 'redux'
 
 import auth from './auth'
 
 export default combineReducers({
-  auth
-});
+  auth,
+})


### PR DESCRIPTION
Replace `eslint-config-react-app` with `eslint-config-airbnb`
--

**Checklist**

- [x] ready to review

**Why?**

@dantix says we need to be more strict 🔨 

**Changes**

* Remove eslint-config-react-app from package.json and ESLint configs
* Add `eslint-config-airbnb` with dependencies and fixed code style accordingly except for `build`, `scripts`, `config` dirs (CRA)
* Add CRA dirs to .eslintignore
* Add a couple of custom ESLint rules for sanity